### PR TITLE
log-counter static linking via journalctl CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ ARG USE_JOURNALCTL=0
 ENV GOPATH /gopath/
 ENV PATH $GOPATH/bin:$PATH
 ENV USE_JOURNALCTL=${USE_JOURNALCTL}
+
+RUN apt-get update --fix-missing && apt-get --yes install libsystemd-dev gcc-aarch64-linux-gnu
 RUN go version
 
 COPY . /gopath/src/k8s.io/node-problem-detector/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,11 @@ FROM builder-base as builder
 LABEL maintainer="Andy Xie <andy.xning@gmail.com>"
 
 ARG TARGETARCH
+ARG USE_JOURNALCTL=0
 
 ENV GOPATH /gopath/
 ENV PATH $GOPATH/bin:$PATH
-
-RUN apt-get update --fix-missing && apt-get --yes install libsystemd-dev gcc-aarch64-linux-gnu
+ENV USE_JOURNALCTL=${USE_JOURNALCTL}
 RUN go version
 
 COPY . /gopath/src/k8s.io/node-problem-detector/

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ For example, to test [KernelMonitor](https://github.com/kubernetes/node-problem-
 - You can see more rule examples under [test/kernel_log_generator/problems](https://github.com/kubernetes/node-problem-detector/tree/master/test/kernel_log_generator/problems).
 - For [KernelMonitor](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json) message injection, all messages should have ```kernel: ``` prefix (also note there is a space after ```:```); or use [generator.sh](https://github.com/kubernetes/node-problem-detector/blob/master/test/kernel_log_generator/generator.sh).
 - To inject other logs into journald like systemd logs, use ```echo 'Some systemd message' | systemd-cat -t systemd```.
+- By default, the `log-counter` (required to read from linux journal) is only compiled for linux OS's - which sets `ENABLE_JOURNALD=1` to produce a dynamically linked binary (`CGO_ENABLED=1`) which uses C-bindings to read from the journal. To produce a statically linked `log-counter` binary, set `USE_JOURNALCTL=1`. With this flag set, the log-counter will instead utilize [`journalctl`](https://www.freedesktop.org/software/systemd/man/journalctl) (must be available in host OS path) to read journal entries.
 
 ## Dependency Management
 

--- a/cmd/logcounter/log_counter.go
+++ b/cmd/logcounter/log_counter.go
@@ -1,5 +1,5 @@
-//go:build journald
-// +build journald
+//go:build (cgo && journald) || journalctl
+// +build cgo,journald journalctl
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/pkg/logcounter/log_counter.go
+++ b/pkg/logcounter/log_counter.go
@@ -1,5 +1,5 @@
-//go:build journald
-// +build journald
+//go:build (cgo && journald) || journalctl
+// +build cgo,journald journalctl
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 
 	"k8s.io/node-problem-detector/cmd/logcounter/options"
@@ -77,6 +78,9 @@ func (e *logCounter) Count() (count int, err error) {
 				err = fmt.Errorf("log channel closed unexpectedly")
 				return
 			}
+
+			klog.V(5).Infof("Received log: %v", log)
+
 			// We only want to count events up until the time at which we started.
 			// Otherwise we would run forever
 			if start.Before(log.Timestamp) {

--- a/pkg/logcounter/log_counter_test.go
+++ b/pkg/logcounter/log_counter_test.go
@@ -1,5 +1,5 @@
-//go:build journald
-// +build journald
+//go:build (cgo && journald) || journalctl
+// +build cgo,journald journalctl
 
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.

--- a/pkg/systemlogmonitor/logwatchers/journald/log_watcher.go
+++ b/pkg/systemlogmonitor/logwatchers/journald/log_watcher.go
@@ -1,5 +1,5 @@
-//go:build journald
-// +build journald
+//go:build cgo && journald
+// +build cgo,journald
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.
@@ -50,6 +50,7 @@ type journaldWatcher struct {
 
 // NewJournaldWatcher is the create function of journald watcher.
 func NewJournaldWatcher(cfg types.WatcherConfig) types.LogWatcher {
+	klog.Info("Using sdjournal library to watch journal logs")
 	uptime, err := util.GetUptimeDuration()
 	if err != nil {
 		klog.Fatalf("failed to get uptime: %v", err)

--- a/pkg/systemlogmonitor/logwatchers/journald/log_watcher_journalctl.go
+++ b/pkg/systemlogmonitor/logwatchers/journald/log_watcher_journalctl.go
@@ -1,0 +1,194 @@
+//go:build journalctl
+// +build journalctl
+
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package journald
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2"
+	"k8s.io/node-problem-detector/pkg/systemlogmonitor/logwatchers/types"
+	logtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
+	"k8s.io/node-problem-detector/pkg/util"
+	"k8s.io/node-problem-detector/pkg/util/tomb"
+)
+
+const (
+	// configSourceKey is the key of source configuration in the plugin configuration.
+	configSourceKey   = "source"
+	entryMessageField = "MESSAGE"
+	entryTimeField    = "__REALTIME_TIMESTAMP"
+)
+
+type journaldWatcher struct {
+	cmd       *exec.Cmd
+	cfg       types.WatcherConfig
+	startTime time.Time
+	logCh     chan *logtypes.Log
+	tomb      *tomb.Tomb
+}
+
+// NewJournaldWatcher is the create function of journald watcher.
+func NewJournaldWatcher(cfg types.WatcherConfig) types.LogWatcher {
+	klog.Info("Using journalctl binary to watch journal logs")
+	uptime, err := util.GetUptimeDuration()
+	if err != nil {
+		klog.Fatalf("failed to get uptime: %v", err)
+	}
+	startTime, err := util.GetStartTime(time.Now(), uptime, cfg.Lookback, cfg.Delay)
+	if err != nil {
+		klog.Fatalf("failed to get start time: %v", err)
+	}
+
+	return &journaldWatcher{
+		cfg:       cfg,
+		startTime: startTime,
+		tomb:      tomb.NewTomb(),
+		// A capacity 1000 buffer should be enough
+		logCh: make(chan *logtypes.Log, 1000),
+	}
+}
+
+// Make sure NewJournaldWatcher is types.WatcherCreateFunc .
+var _ types.WatcherCreateFunc = NewJournaldWatcher
+
+// Watch starts the journal watcher.
+func (j *journaldWatcher) Watch() (<-chan *logtypes.Log, error) {
+	args := []string{
+		"--identifier",
+		j.cfg.PluginConfig[configSourceKey],
+		"--since",
+		j.startTime.Format(time.DateTime),
+		"--output",
+		"json",
+	}
+	if j.cfg.LogPath != "" {
+		if _, err := os.Stat(j.cfg.LogPath); err != nil {
+			return nil, fmt.Errorf("failed to stat the log path %q: %v", j.cfg.LogPath, err)
+		}
+		args = append(args, "--directory", j.cfg.LogPath)
+	}
+	j.cmd = exec.Command("journalctl", args...)
+
+	klog.V(4).Infof("Running journalctl command: %v", j.cmd)
+
+	stdout, err := j.cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stdout pipe: %v", err)
+	}
+
+	stderr, err := j.cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stderr pipe: %v", err)
+	}
+
+	if err := j.cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start journalctl command: %v", err)
+	}
+
+	go j.watchLoop(stdout, stderr)
+	return j.logCh, nil
+}
+
+// Stop stops the journald watcher.
+func (j *journaldWatcher) Stop() {
+	j.tomb.Stop()
+	if j.cmd != nil && j.cmd.Process != nil {
+		j.cmd.Process.Kill()
+	}
+}
+
+func (j *journaldWatcher) watchLoop(stdout io.ReadCloser, stderr io.ReadCloser) {
+	defer j.tomb.Done()
+
+	// handle stderr to propagate errors
+	go func() {
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			klog.Errorf("journalctl error: %s", scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			klog.Errorf("error reading stderr: %v", err)
+		}
+	}()
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		select {
+		case <-j.tomb.Stopping():
+			klog.Infof("Stop watching journalctl")
+			return
+		default:
+			line := scanner.Text()
+			log, err := parseJournalctlOutput(line)
+			if err != nil {
+				klog.Errorf("failed to parse journalctl output: %v", err)
+				continue
+			}
+			j.logCh <- log
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		klog.Errorf("error reading journalctl output: %v", err)
+	}
+
+	// wait for the command to complete and check its exit status
+	if err := j.cmd.Wait(); err != nil {
+		klog.Errorf("journalctl command failed: %v", err)
+		os.Exit(2)
+	}
+}
+
+func parseJournalctlOutput(line string) (*logtypes.Log, error) {
+	// parse the JSON output from journalctl
+	var entry map[string]interface{}
+	if err := json.Unmarshal([]byte(line), &entry); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal journalctl output: %v", err)
+	}
+
+	message, ok := entry[entryMessageField].(string)
+	if !ok {
+		return nil, fmt.Errorf("missing %s field in journalctl output", entryMessageField)
+	}
+
+	realtimeTimestamp, ok := entry[entryTimeField].(string)
+	if !ok {
+		return nil, fmt.Errorf("missing %s field in journalctl output", entryTimeField)
+	}
+
+	// convert the __REALTIME_TIMESTAMP from microseconds to time.Time
+	timestampInt, err := strconv.ParseInt(realtimeTimestamp, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %v", entryTimeField, err)
+	}
+	timestamp := time.Unix(0, timestampInt*int64(time.Microsecond))
+
+	return &logtypes.Log{
+		Timestamp: timestamp,
+		Message:   strings.TrimSpace(message),
+	}, nil
+}

--- a/pkg/systemlogmonitor/logwatchers/journald/log_watcher_journalctl_test.go
+++ b/pkg/systemlogmonitor/logwatchers/journald/log_watcher_journalctl_test.go
@@ -1,0 +1,105 @@
+//go:build journalctl
+// +build journalctl
+
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package journald
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/node-problem-detector/pkg/systemlogmonitor/logwatchers/types"
+	logtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
+)
+
+func TestParseJournalctlOutput(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	testCases := []struct {
+		entry    string
+		log      *logtypes.Log
+		errorMsg *string
+	}{
+		{
+			// has log message
+			entry: "{\"__REALTIME_TIMESTAMP\":\"1234567890123456\",\"MESSAGE\":\"This is a test log message\"}",
+			log: &logtypes.Log{
+				Timestamp: time.Unix(0, 1234567890123456*1000),
+				Message:   "This is a test log message",
+			},
+			errorMsg: nil,
+		},
+		{
+			// log message has additional fields
+			entry: "{\"__REALTIME_TIMESTAMP\":\"1234567890123456\",\"MESSAGE\":\"another log message\",\"__MONOTONIC_TIMESTAMP\":\"123456789\"}",
+			log: &logtypes.Log{
+				Timestamp: time.Unix(0, 1234567890123456*1000),
+				Message:   "another log message",
+			},
+			errorMsg: nil,
+		},
+		{
+			// log message has invalid __REALTIME_TIMESTAMP field
+			entry:    "{\"__REALTIME_TIMESTAMP\":\"123abc\",\"MESSAGE\":\"another log message\",\"__MONOTONIC_TIMESTAMP\":\"123456789\"}",
+			errorMsg: strPtr("failed to parse __REALTIME_TIMESTAMP: strconv.ParseInt: parsing \"123abc\": invalid syntax"),
+		},
+		{
+			// missing __REALTIME_TIMESTAMP field
+			entry:    "{\"MESSAGE\":\"This is a test log message\"}",
+			errorMsg: strPtr("missing __REALTIME_TIMESTAMP field in journalctl output"),
+		},
+		{
+			// missing MESSAGE field
+			entry:    "{\"__REALTIME_TIMESTAMP\":\"1719976451991183\"}",
+			errorMsg: strPtr("missing MESSAGE field in journalctl output"),
+		},
+		{
+			// no log message
+			entry:    "",
+			errorMsg: strPtr("failed to unmarshal journalctl output: unexpected end of JSON input"),
+		},
+	}
+
+	for c, test := range testCases {
+		t.Logf("TestCase #%d: %#v", c+1, test)
+		out, err := parseJournalctlOutput(test.entry)
+		if test.errorMsg != nil {
+			assert.Error(t, err, "Expected parseJournalctlOutput to return an error.")
+			assert.Equal(t, *test.errorMsg, err.Error())
+		} else {
+			assert.NoError(t, err, "Expected parseJournalctlOutput error to be nil.")
+			assert.Equal(t, test.log, out)
+		}
+	}
+}
+
+func TestGoroutineLeak(t *testing.T) {
+	original := runtime.NumGoroutine()
+	w := NewJournaldWatcher(types.WatcherConfig{
+		Plugin:       "journald",
+		PluginConfig: map[string]string{"source": "not-exist-service"},
+		LogPath:      "/not/exist/path",
+		Lookback:     "10m",
+	})
+	_, err := w.Watch()
+	assert.Error(t, err)
+	assert.Equal(t, original, runtime.NumGoroutine())
+}

--- a/pkg/systemlogmonitor/logwatchers/journald/log_watcher_test.go
+++ b/pkg/systemlogmonitor/logwatchers/journald/log_watcher_test.go
@@ -1,5 +1,5 @@
-//go:build journald
-// +build journald
+//go:build cgo && journald
+// +build cgo,journald
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.

--- a/pkg/systemlogmonitor/logwatchers/register_journald.go
+++ b/pkg/systemlogmonitor/logwatchers/register_journald.go
@@ -1,5 +1,5 @@
-//go:build journald
-// +build journald
+//go:build (cgo && journald) || journalctl
+// +build cgo,journald journalctl
 
 /*
 Copyright 2016 The Kubernetes Authors All rights reserved.


### PR DESCRIPTION
## Background

Currently building `log-counter` requires `CGO_ENABLED` since there is a dependency on `github.com/coreos/go-systemd/v22/sdjournal` which uses C-bindings to read system journal.
This essentially produces a dynamically linked binary which is not portable across different versions of the same OS.

This is especially an issue if you want to build a binary which is portable across different versions of the same OS.

## Static linking
This PR adds support for static-linking to the `log-counter` - such that the log-counter calls out to the `journalctl` binary instead (which must be available in the host system) to read system journal entries.